### PR TITLE
Issue#68 : Histogram to depict no. of tracks v/s no. of users

### DIFF
--- a/Spotify Recommendation/Spotify Playlist Recommender.ipynb
+++ b/Spotify Recommendation/Spotify Playlist Recommender.ipynb
@@ -2049,7 +2049,53 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#TODO Create a histogram showing the distribution of the number of tracks added by each user.\n"
+    "#TODO Create a histogram showing the distribution of the number of tracks added by each user.\n",
+    "import matplotlib.pyplot as plt\n",
+    "track_counts = df_playlist.groupby('user_id').size()\n",
+    "print(track_counts.describe())  # Check the statistical summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87f40a2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#plotting a histogram with original data\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.hist(track_counts, bins=50, color='skyblue')\n",
+    "max_tracks = track_counts.max() \n",
+    "plt.title('Distribution of Number of Tracks Added by Each User')\n",
+    "plt.xlabel('Number of Tracks')\n",
+    "plt.ylabel('Number of Users')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52b8161c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#this graph shows that the data is skewed and thus we need to scale it thus used logarithmic scaling\n",
+    "log_data = np.log10(track_counts)\n",
+    "\n",
+    "# Plot the histogram of the transformed data\n",
+    "plt.figure(figsize=(12, 6))\n",
+    "plt.hist(log_data, bins=50, color='skyblue', alpha=0.8)\n",
+    "\n",
+    "# Customize labels and title\n",
+    "plt.title('Log-Transformed Histogram of Number of Tracks Added by Users')\n",
+    "plt.xlabel('Log10(Number of Tracks)')\n",
+    "plt.ylabel('Frequency')\n",
+    "\n",
+    "# Add gridlines for better readability\n",
+    "plt.grid(axis='y', alpha=0.75)\n",
+    "\n",
+    "# Show the plot\n",
+    "plt.show()"
    ]
   },
   {


### PR DESCRIPTION
Fixes issue #68 
![image](https://github.com/user-attachments/assets/8d8acf77-43fa-4964-8519-8da3424f1729)
![image](https://github.com/user-attachments/assets/302e63d5-86ce-42ef-b5c7-cf7b54e45ff1)
![image](https://github.com/user-attachments/assets/29e1dcc3-6e55-4725-b2cd-4ca1c452da60)
![image](https://github.com/user-attachments/assets/8125d278-9636-470a-ac6f-673213d9c1a1)


This PR creates a histogram to depict the number of tracks added by users in their playlists.