### PR TITLE
Add requirements.txt for Seqnet 

### DIFF
--- a/Seqnet/requirements.txt
+++ b/Seqnet/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+tensorflow
+numpy


### PR DESCRIPTION
Adds requirements.txt to document dependencies and simplify setup for contributors.
