### PR TITLE
Add dynamic dataset upload, display stats, and store dataset metadata

### DIFF
--- a/Seqnet/utils.py
+++ b/Seqnet/utils.py
@@ -4,6 +4,8 @@ from tensorflow.keras.preprocessing.text import Tokenizer
 from tensorflow.keras.preprocessing.sequence import pad_sequences
 import pickle
 import os
+import json
+from datetime import datetime
 
 def load_data(file_path):
     with open(file_path, 'r', encoding='utf-8') as f:
@@ -47,3 +49,16 @@ def load_tokenizer(path):
     with open(path, 'rb') as handle:
         tokenizer = pickle.load(handle)
     return tokenizer
+
+def save_dataset_metadata(metadata, path="dataset_metadata.json"):
+    metadata["timestamp"] = datetime.utcnow().isoformat()
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(metadata) + "\n")
+
+def compute_dataset_stats(text):
+    lines = text.splitlines()
+    return {
+        "lines": len(lines),
+        "characters": len(text),
+        "avg_line_length": sum(len(line) for line in lines) / max(len(lines), 1)
+    }


### PR DESCRIPTION
Decouple Training from data.txt and Add Dynamic Dataset Upload with Stats & Metadata Issue #63 

## Overview

This PR improves the Seqnet LSTM text completion app by:

1. Allowing **dynamic dataset upload** (`.txt` files) instead of being tied to `data.txt`.  
2. Validating uploaded datasets:
   - **File size** (max 10MB)  
   - **UTF-8 encoding**  
3. Displaying **dataset statistics** in the sidebar:
   - Number of lines  
   - Total characters  
   - Average line length  
4. Storing **dataset metadata** (`dataset_metadata.json`) including filename, size, encoding, stats, and timestamp.  
5. Maintaining **backward compatibility** with the default `data.txt` dataset.  
6. Fully integrated with the existing **training and prediction pipeline**.

---

## Changes Made

- **`app.py`**  
  - Added **file uploader** in sidebar.  


  - Updated **training logic** to use uploaded file if present.  
  - Displays **dataset statistics** dynamically.  
  - Saves **dataset metadata**.  

- **`utils.py`**  
  - Added `compute_dataset_stats(text)`  
  - Added `save_dataset_metadata(metadata)`  

---

## Screenshots
<img width="1284" height="694" alt="Screenshot 2026-01-22 at 1 38 46 AM" src="https://github.com/user-attachments/assets/23a64a03-8eac-421b-bc6d-9b6d9752eedc" />

