### PR TITLE
#55 Add confidence threshold and logging for low-confidence predictions

### DIFF
--- a/Mythos AI/low_confidence_logs.csv
+++ b/Mythos AI/low_confidence_logs.csv
@@ -1,0 +1,3 @@
+Title,Predicted Genre,Confidence
+The Silent Forest,Literature & Fiction,0.22462383071658784
+life,Sports,0.23902652834074345


### PR DESCRIPTION
fixes #55.

Changes Made:

-Added CONFIDENCE_THRESHOLD in app.py to detect low-confidence predictions (<40%).
-Implemented logic to check max_prob and trigger warnings for uncertain titles.
-Added user-friendly messages (st.warning & st.info) explaining prediction uncertainty.
-Logged low-confidence cases to low_confidence_logs.csv for future analysis.

<img width="1314" height="819" alt="Screenshot 2026-01-25 133641" src="https://github.com/user-attachments/assets/e7cad7e2-2935-48ea-94af-4dc3a4afe7ec" />
