### PR TITLE
Moodify: Added lyric language detection

### DIFF
--- a/Moodify/app.py
+++ b/Moodify/app.py
@@ -4,6 +4,7 @@ import joblib
 from sklearn.metrics.pairwise import cosine_similarity
 from preprocessing import preprocess_text
 from train_model import predict_emotion, explain_prediction
+from langdetect import detect, LangDetectException
 
 
 
@@ -224,11 +225,20 @@ if st.button("Predict Vibe"):
     elif word_count < MIN_WORDS: 
         st.info( f"Please enter at least **{MIN_WORDS} words** for accurate emotion prediction.\n\n" f"Current word count: **{word_count}**" )
     else:
+        # Detect language
+        try:
+            detected_lang = detect(lyrics_input)
+        except LangDetectException:
+            detected_lang = None
+
+        if detected_lang != "en":
+            st.warning("Moodify currently only supports English lyrics.")
+            st.stop()
+
         # Preprocess input
         lyrics_clean = preprocess_text(lyrics_input)
         vec = tfidf.transform([lyrics_clean])
-        
-        # Predict emotion
+
         # Predict emotion
         pred_labels = predict_emotion(lyrics_input, tfidf, clf, le)
         dominant_emotion, dominant_prob = pred_labels[0]  # <-- add this line

--- a/Moodify/requirements.txt
+++ b/Moodify/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn
 joblib
 nltk
 spellchecker
+langdetect


### PR DESCRIPTION
## Moodify: Added Lyric Language Detection - Issue #17 

This PR introduces **language detection** to prevent invalid predictions:

- Detects the language of user-input lyrics using `langdetect`
- Stops the prediction pipeline if the detected language is not English
- Displays a clear user-facing warning:
  > **“Moodify currently only supports English lyrics.”**

---

### Implementation Details
- Added `langdetect` as a dependency
- Performed language detection before preprocessing and model inference
- Used `st.warning()` to notify the user
- Used `st.stop()` to safely halt execution
- Wrapped detection logic in a try/except block to handle edge cases

---

### How to Test
1. Run the Streamlit app locally
2. Paste **English lyrics** → emotion prediction runs normally
3. Paste **non-English lyrics** (e.g., Spanish or French) → warning is shown and no prediction is made

<img width="1267" height="626" alt="Screenshot 2026-01-29 at 11 41 23 AM" src="https://github.com/user-attachments/assets/2a7fd336-a4de-4d10-ae38-8acf42d331b9" />

