### PR TITLE
Add vegan and gluten-free toggles with dataset filtering and retraine…

### DIFF
--- a/ReMixRecipe/app.py
+++ b/ReMixRecipe/app.py
@@ -68,9 +68,9 @@ def load_model():
     return predictor
 
 @st.cache_resource
-def load_recommender():
+def load_recommender(vegan=False, gluten_free=False):
     data_path = os.path.join(os.path.dirname(__file__), 'data', 'recipes.csv')
-    return RecipeRecommender(data_path=data_path)
+    return RecipeRecommender(data_path=data_path, vegan=vegan, gluten_free=gluten_free)
 
 # -----------------------------
 # Main Application
@@ -80,18 +80,23 @@ def main():
     st.markdown("### Turn your leftovers into a masterpiece!")
     st.markdown("Enter the ingredients you have, and our AI will guess the best cuisine for you.")
 
-    # Load models
-    try:
-        predictor = load_model()
-        recommender = load_recommender()
-    except Exception as e:
-        st.error(f"Error loading model: {e}")
-        return
-
     # Input Section
     st.markdown("---")
     ingredients_input = st.text_area("What's in your fridge? (comma separated)", 
                                      placeholder="e.g. tomato, cheese, basil, garlic")
+    
+    vegan_only = st.checkbox("🌱 Vegan recipes only")
+    gluten_free_only = st.checkbox("🚫 Gluten-free recipes only")
+
+        # Load models
+    try:
+        predictor = load_model()
+        recommender = load_recommender(vegan_only, gluten_free_only)
+
+    except Exception as e:
+        st.error(f"Error loading model: {e}")
+        return
+
     
     language = st.selectbox(
     "Choose language",


### PR DESCRIPTION
fixes #27 

This PR adds Vegan and Gluten-Free filter options to the ReMixRecipe app so users can get recipe recommendations based on their dietary needs.

What’s added:
-Two checkboxes in the UI for Vegan and Gluten-Free recipes.
-Recipe filtering to remove:
animal-based ingredients for vegan selection
gluten ingredients for gluten-free selection
-TF-IDF recommender retrains on the filtered dataset to keep recommendations accurate.

Screenshots:
<img width="1808" height="884" alt="Screenshot 2026-02-07 011232" src="https://github.com/user-attachments/assets/5e5bb449-27d6-4bc6-ba2a-09dff5457b07" />
<img width="1764" height="885" alt="Screenshot 2026-02-07 011246" src="https://github.com/user-attachments/assets/fa82049b-5f5e-47ce-a844-6c8727b40a56" />
<img width="1667" height="900" alt="Screenshot 2026-02-07 011343" src="https://github.com/user-attachments/assets/58a2fade-2788-45e5-b48f-6ddfe4a4928b" />
<img width="1791" height="878" alt="Screenshot 2026-02-07 011355" src="https://github.com/user-attachments/assets/bb84b34a-73d1-4e33-a50d-ea002d55dfd1" />
