### PR TITLE
Add requirements.txt for Mythos AI dependencies

### DIFF
--- a/Mythos AI/requirements.txt
+++ b/Mythos AI/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+pandas
+scikit-learn
+joblib


### PR DESCRIPTION
Added requirements.txt containing required dependencies for Mythos AI module.

Dependencies included:
- streamlit
- pandas
- scikit-learn
- joblib

This helps contributors set up environment and run the project easily.

Closes #52 