### PR TITLE
Handle out-of-distribution inputs using confidence threshold and neutral state

### DIFF
--- a/VibeLift/app.py
+++ b/VibeLift/app.py
@@ -362,18 +362,20 @@ if detect_button:
                     raw_pred = clf.predict(X)[0] 
                     proba = float(clf.predict_proba(X).max())
                     
-                    # Capitalize prediction to match EMOJI_MAP keys
-                    pred = raw_pred.capitalize() 
+                    CONFIDENCE_THRESHOLD = 0.40
+                    if proba < CONFIDENCE_THRESHOLD:
+                        pred = "Neutral"
+                    else:
+                        pred = raw_pred.capitalize()
 
             except Exception as e:
                 st.error(f"Prediction failed! The model is incompatible or corrupt. Error: {e}")
 
         # Update Session State for Display
-        if pred in EMOJI_MAP:
+        if pred in EMOJI_MAP or pred == "Neutral":
             st.session_state['final_pred'] = pred
         else:
             st.session_state['final_pred'] = "Unknown"
-        st.session_state['proba'] = proba
 
 if reset_button:
     st.session_state['detect_clicked'] = False
@@ -387,6 +389,10 @@ if st.session_state['detect_clicked'] and st.session_state['final_pred'] is not 
     final_pred = st.session_state['final_pred']
     proba = st.session_state['proba']
     emoji = EMOJI_MAP.get(final_pred, "🧠")
+    if final_pred == "Neutral":
+        st.info("I'm sensing a neutral vibe. Could you describe your feelings in more detail?")
+        st.stop()
+
 
     st.markdown("---")
     st.markdown(


### PR DESCRIPTION
This PR improves emotion prediction reliability by handling out-of-distribution (OOD) inputs such as gibberish, numeric text, or unrelated content.
Changes made:
- Added a confidence threshold of 0.40 using predict_proba()
- If confidence is below threshold, the app shows a Neutral state
- Displays a message asking the user to describe feelings more clearly
- Prevented exercises and images from displaying for Neutral state

Tested with:
- Emotional sentences (works correctly)
- Numeric and random inputs like "12345" and 'print("hello")' (now handled properly)
<img width="1053" height="554" alt="Screenshot 2026-02-09 135639" src="https://github.com/user-attachments/assets/c439f930-40e3-4f41-a5ee-5644bf1b1ee4" />

