### PR TITLE
Fix NLP abbreviation mismatch using synonym normalization

### DIFF
--- a/ResuMatch/app.py
+++ b/ResuMatch/app.py
@@ -12,6 +12,7 @@ from langdetect import detect
 from PyPDF2 import PdfReader
 from docx import Document
 
+
 def safe_extract_text_from_pdf(file):
     try:
         pdf = PdfReader(file)

--- a/ResuMatch/test_ats.py
+++ b/ResuMatch/test_ats.py
@@ -1,0 +1,25 @@
+from utils import (
+    calculate_ats_score,
+    calculate_similarity,
+    get_missing_keywords,
+    clean_text
+)
+
+resume = """
+Python developer with experience in machine learning, NLP, and Flask.
+Completed internship and built 3 projects using TensorFlow and SQL.
+Bachelor degree in Computer Science.
+"""
+
+job_desc = """
+Looking for a Python developer with experience in ML,
+deep learning, NLP, SQL, and TensorFlow. Internship experience preferred.
+"""
+
+# Clean text first
+resume_clean = clean_text(resume)
+jd_clean = clean_text(job_desc)
+
+print("ATS Score:", calculate_ats_score(resume_clean, jd_clean))
+print("Similarity:", calculate_similarity(resume_clean, jd_clean))
+print("Missing Keywords:", get_missing_keywords(resume_clean, jd_clean))

--- a/ResuMatch/utils.py
+++ b/ResuMatch/utils.py
@@ -16,6 +16,32 @@ try:
 except LookupError:
     nltk.download('stopwords')
 
+SYNONYM_MAP = {
+        "ml": "machine learning",
+        "machine learning": "machine learning",
+
+        "nlp": "natural language processing",
+        "natural language processing": "natural language processing",
+
+        "ai": "artificial intelligence",
+        "artificial intelligence": "artificial intelligence",
+
+        "js": "javascript",
+        "javascript": "javascript",
+
+        "dl": "deep learning",
+        "deep learning": "deep learning"
+}
+
+def normalize_synonyms(text):
+    text = text.lower()
+
+    for key, value in SYNONYM_MAP.items():
+        text = text.replace(key, value)
+
+    return text
+
+
 def calculate_ats_score(resume_text, job_desc_text):
     """
     Simulates a realistic ATS scoring system.
@@ -25,6 +51,11 @@ def calculate_ats_score(resume_text, job_desc_text):
     if not resume_text or not job_desc_text:
         return 0
 
+    
+    resume_text = normalize_synonyms(resume_text)
+    job_desc_text = normalize_synonyms(job_desc_text)
+
+    #Create word sets  ← MISSING PART
     resume_words = set(resume_text.split())
     jd_words = set(job_desc_text.split())
 
@@ -63,6 +94,9 @@ def calculate_ats_score(resume_text, job_desc_text):
     ats_score = keyword_score + skill_score + exp_score + format_score
 
     return round(ats_score, 2)
+
+
+
 
 def extract_text_from_docx(uploaded_file):
     doc = Document(uploaded_file)
@@ -138,6 +172,9 @@ def calculate_similarity(resume_text, job_desc_text):
 
     if not resume_text or not job_desc_text:
         return 0.0
+    
+    resume_text = normalize_synonyms(resume_text)
+    job_desc_text = normalize_synonyms(job_desc_text)
     content = [resume_text, job_desc_text]
     
     tfidf = TfidfVectorizer()
@@ -158,6 +195,8 @@ def get_missing_keywords(resume_text, job_desc_text, top_n=10):
     # Strategy: Get top TF-IDF words from JD, check if they are in Resume
     if not resume_text or not job_desc_text:
         return []
+    resume_text = normalize_synonyms(resume_text)
+    job_desc_text = normalize_synonyms(job_desc_text)
     tfidf_jd = TfidfVectorizer(max_features=20) # Get top feature words
     tfidf_jd.fit([job_desc_text])
     
@@ -168,5 +207,5 @@ def get_missing_keywords(resume_text, job_desc_text, top_n=10):
     resume_words = set(resume_text.split())
     
     missing_keywords = [word for word in feature_names if word not in resume_words]
-            
+    
     return missing_keywords


### PR DESCRIPTION
fixes #37 

Resolves inaccurate ATS scoring and similarity results caused by abbreviation mismatches (e.g., "ML" vs "Machine Learning").

Changes
-Added a SYNONYM_MAP to standardize common AI/tech abbreviations:
ML → Machine Learning
NLP → Natural Language Processing
AI → Artificial Intelligence
JS → JavaScript
DL → Deep Learning

-Implemented a normalize_synonyms() function to preprocess resume and job description text before:

-ATS score calculation
Cosine similarity computation
Missing keyword extraction
Ensured normalization is consistently applied across all NLP evaluation functions.

Screenshots:
<img width="892" height="713" alt="Screenshot 2026-02-15 141343" src="https://github.com/user-attachments/assets/6645f08a-3d05-478c-883d-66b44d85a2df" />
<img width="534" height="109" alt="Screenshot 2026-02-15 141349" src="https://github.com/user-attachments/assets/7b07f7dc-c412-49cb-aa73-6517c7667687" />
